### PR TITLE
fix(editor): 移除预览加载状态和相关逻辑 fix #3

### DIFF
--- a/app/components/editor/EditorPreview.vue
+++ b/app/components/editor/EditorPreview.vue
@@ -2,11 +2,9 @@
 const {
   computedLayers,
   cardWidthNumber,
-  isPreviewReady,
   forceInteracting,
   importModalOpen,
   importJsonDraft,
-  onPreviewReady,
   handleImport,
 } = useEditorStateInjection();
 
@@ -20,33 +18,12 @@ const cssPreviewOpen = ref(false);
   <!-- 工具栏插槽 -->
   <slot name="toolbar" />
 
-  <!-- 预览加载指示器 -->
-  <Transition name="preview-fade">
-    <div
-      v-if="!isPreviewReady"
-      class="absolute inset-0 z-30 flex items-center justify-center pointer-events-none"
-    >
-      <div
-        class="flex items-center gap-2 px-4 py-2 rounded-xl bg-white/70 dark:bg-neutral-900/70 backdrop-blur-sm border border-neutral-200/50 dark:border-neutral-700/50 shadow"
-      >
-        <UIcon
-          name="i-lucide-loader-2"
-          class="size-4 text-neutral-500 animate-spin"
-        />
-        <span class="text-xs text-neutral-500">{{
-          $t("editor.previewLoading")
-        }}</span>
-      </div>
-    </div>
-  </Transition>
-
   <!-- 卡片预览 -->
   <div class="relative z-10">
     <ShineCard
       :layers="computedLayers"
       :width="`${cardWidthNumber}px`"
       :force-interacting="forceInteracting"
-      @ready="onPreviewReady"
     />
   </div>
 

--- a/app/composables/useEditorState.ts
+++ b/app/composables/useEditorState.ts
@@ -74,7 +74,6 @@ export function useEditorState() {
   const schemeDeleteDisabled = computed(() => schemes.value.length <= 1);
   const importModalOpen = ref(false);
   const importJsonDraft = ref("");
-  const isPreviewReady = ref(true);
   const forceInteracting = ref(false);
 
   // 方案快捷键
@@ -105,25 +104,6 @@ export function useEditorState() {
       selectedLayerIndex.value = Math.max(0, l.length - 1);
     }
   });
-
-  // 预览加载状态
-
-  // 方案/图层变化时重置 ready 状态
-  watch(
-    [
-      activeSchemeId,
-      () => layers.value.map((l) => `${l.id}:${l.img}`).join(","),
-    ],
-    () => {
-      if (computedLayers.value.length > 0) {
-        isPreviewReady.value = false;
-      }
-    },
-  );
-
-  function onPreviewReady() {
-    isPreviewReady.value = true;
-  }
 
   // 方案操作
 
@@ -237,7 +217,6 @@ export function useEditorState() {
   }
 
   // 计算图层（用于 ShineCard 预览）
-
   const computedLayers = computed<ParallaxLayer[]>(() => {
     const scheme = activeScheme.value;
     if (!scheme) return [];
@@ -254,7 +233,6 @@ export function useEditorState() {
   });
 
   // 导出
-
   function exportConfig(format: ExportFormat = "ts") {
     const cardWidth = activeScheme.value?.cardWidth;
     const data = computedLayers.value;
@@ -363,7 +341,6 @@ export function useEditorState() {
     schemeDeleteDisabled,
     importModalOpen,
     importJsonDraft,
-    isPreviewReady,
     forceInteracting,
 
     // 派生状态
@@ -392,7 +369,6 @@ export function useEditorState() {
     removeLayer,
     duplicateLayer,
     toggleLayerVisibility,
-    onPreviewReady,
 
     // 效果操作
     getEffectMode,


### PR DESCRIPTION
导致问题 #3 的原因是由`isPreviewReady`的状态初始化逻辑和监听点不正确导致的。
- `isPreviewReady`默认被设定为ture
- `isPreviewReady`所对应的`watch`监听器没有设置为`immediate： true`导致其值不能被正确初始化
---
经过判断，确定`isPreviewReady`为无意义，其对应的提示也无意义。直接删除相关内容。